### PR TITLE
Add dynamic logging config to the CF distribution

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -68,3 +68,15 @@ variable "cloudfront_geo_restriction_locations" {
   }
 
 }
+
+variable "logging_bucket" {
+  type        = string
+  description = "An existing bucket to log requests to, null if no logging"
+  default     = ""
+}
+
+variable "logging_prefix" {
+  type        = string
+  description = "A prefix for the logging_bucket, null if not used"
+  default     = ""
+}


### PR DESCRIPTION
Forked this repo because the upstream looks mostly dead.

Adding in capability for logging requests for the distribution.  

Linear issue:  https://linear.app/nomic/issue/INF-182/enable-logging-for-staticnomicai-distribution-e13aguxl1mnvfn

Hopefully, this all works and upstream takes it